### PR TITLE
Chore: Add color assets

### DIFF
--- a/Gesture-Study/Gesture-Study/Assets.xcassets/BackgroundColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/BackgroundColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x25",
+          "green" : "0x25",
+          "red" : "0x25"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Assets.xcassets/GrayColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/GrayColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9B",
+          "green" : "0x9B",
+          "red" : "0x9B"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Assets.xcassets/PrimaryColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/PrimaryColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.465",
+          "green" : "0.447",
+          "red" : "0.966"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Assets.xcassets/SubTextColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/SubTextColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.800",
+          "blue" : "255",
+          "green" : "255",
+          "red" : "255"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockBottomColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockBottomColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x25",
+          "green" : "0x25",
+          "red" : "0x25"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockButtonBottomColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockButtonBottomColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9C",
+          "green" : "0x9C",
+          "red" : "0x9C"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockButtonCenterColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockButtonCenterColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xB2",
+          "green" : "0xB2",
+          "red" : "0xB2"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockButtonTopColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockButtonTopColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xEE",
+          "green" : "0xEE",
+          "red" : "0xEE"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockTextColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockTextColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x4E",
+          "green" : "0x4E",
+          "red" : "0x4E"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockTopColor.colorset/Contents.json
+++ b/Gesture-Study/Gesture-Study/Assets.xcassets/SwipeToUnlockTopColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x09",
+          "green" : "0x09",
+          "red" : "0x09"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Gesture-Study/Gesture-Study/Resource/Colors.swift
+++ b/Gesture-Study/Gesture-Study/Resource/Colors.swift
@@ -1,0 +1,21 @@
+//
+//  Colors.swift
+//  Gesture-Study
+//
+//  Created by JongHo Park on 2022/04/27.
+//
+
+import Foundation
+import SwiftUI
+
+extension Color {
+  static let primary: Color = Color("PrimaryColor")
+  static let grayButton: Color = Color("GrayColor")
+  static let subText: Color = Color("SubTextColor")
+  static let stuTop: Color = Color("SwipeToUnlockTopColor")
+  static let stuBottom: Color = Color("SwipeToUnlockBottomColor")
+  static let stuBtnTop: Color = Color("SwipeToUnlockButtonTopColor")
+  static let stuBtnCenter: Color = Color("SwipeToUnlockButtonCenterColor")
+  static let stuBtnBottom: Color = Color("SwipeToUnlockButtonBottomColor")
+  static let background: Color = Color("BackgroundColor")
+}


### PR DESCRIPTION
## 개요
프로젝트 전반적으로 사용되는 컬러 에셋 추가

## 작업사항
- 프로젝트 전반적으로 사용되는 컬러 에셋 추가
- Color extension 으로 에셋에 추가된 컬러 타입 프로퍼티로 추가

## 사용방법
Color extension 을 통해 Color 타입을 받는 모든 곳에서 쉽게 사용 가능
<img width="520" alt="image" src="https://user-images.githubusercontent.com/57793298/165472315-2f7d923e-a38c-40c6-a8d5-26aaef020c4e.png">

## 기타
- 특정 View 에서만 사용되는 Color 임이 확실할 때, 해당 View 의 Extension 으로 컬러를 정의해서 API 노출을 최소화시키는게 좋을지를 고민해봐야 함 (Swipe To Unlock 색상 모음의 경우, SwipeToUnlockView 의 extension 으로 정의할지)

**ex)**

```swift
struct SwipeToUnlockView: View {
  ...
}

extension SwipeToUnlockView {
  static let swipeToUnlockColor: Color = Color("SwipeToUnlock")
}
```
