### PR TITLE
Feat/#14_Add_gesture_detail_view

### DIFF
--- a/Gesture-Study/GestureStudy/GestureDetail/Tap.swift
+++ b/Gesture-Study/GestureStudy/GestureDetail/Tap.swift
@@ -17,11 +17,11 @@ struct Tap: GestureDetailProtocol {
 
   let korNm: String = "탭"
 
-  let swiftCode: String = ""
+  let swiftCode: String = "import SwiftUI"
 
   let image: Image = Image(systemName: "hand.tap.fill")
 
-  let shortDescription: String = "탭임"
+  let shortDescription: String = "단순히 화면을 한 번 터치하는 제스처입니다.\n화면을 터치해보세요!"
 
   let exampleView: Text = Text("하하!")
 

--- a/Gesture-Study/GestureStudy/View/BottomSheetContainer.swift
+++ b/Gesture-Study/GestureStudy/View/BottomSheetContainer.swift
@@ -1,0 +1,66 @@
+//
+//  BottomSheetContainer.swift
+//  GestureStudy
+//
+//  Created by JongHo Park on 2022/04/29.
+//
+
+import SwiftUI
+
+struct BottomSheetContainer<Content: View>: View {
+
+  private let content: () -> Content
+  @Environment(\.dismiss) private var dismiss
+
+  init(content: @escaping () -> Content) {
+    self.content = content
+  }
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      topView
+      content()
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .background(Color.background)
+  }
+
+  private var topView: some View {
+    HStack(alignment: .center) {
+      Spacer()
+        .frame(maxWidth: .infinity)
+      touchIndicator
+        .frame(maxWidth: .infinity)
+      HStack {
+        Spacer()
+        closeButton
+      }
+      .frame(maxWidth: .infinity)
+    }
+  }
+  private var touchIndicator: some View {
+    RoundedRectangle(cornerRadius: 6)
+      .fill(Color.grayButton)
+      .frame(width: 130, height: 5)
+  }
+
+  private var closeButton: some View {
+    Button {
+      dismiss()
+    } label: {
+      Image(systemName: "xmark.circle")
+        .foregroundColor(.grayButton)
+    }
+    .padding()
+    .contentShape(Rectangle())
+    .buttonStyle(.plain)
+  }
+}
+
+struct BottomSheetContainer_Previews: PreviewProvider {
+  static var previews: some View {
+    BottomSheetContainer {
+      Text("하이")
+    }
+  }
+}

--- a/Gesture-Study/GestureStudy/View/GestureDetailContainer.swift
+++ b/Gesture-Study/GestureStudy/View/GestureDetailContainer.swift
@@ -7,14 +7,15 @@
 
 import SwiftUI
 
+// MARK: - 제스처 디테일 컨테이너
 struct GestureDetailContainer<GestureDetail: GestureDetailProtocol>: View {
   @State private var detailType: DetailType = .example
+  @State private var showSheet: Bool = false
   private let gestureDetail: GestureDetail
 
   init(detail gestureDetail: GestureDetail) {
     self.gestureDetail = gestureDetail
     UISegmentedControl.appearance().selectedSegmentTintColor = UIColor(.brand)
-
   }
 
   var body: some View {
@@ -23,6 +24,9 @@ struct GestureDetailContainer<GestureDetail: GestureDetailProtocol>: View {
         simpleDescription
       }
       content
+    }
+    .sheet(isPresented: $showSheet) {
+      BottomSheetContainer(content: { gestureDetail.detailDescription })
     }
     .navigationTitle(gestureDetail.enNm)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -68,7 +72,7 @@ extension GestureDetailContainer {
       segmentedPicker
     }
     ToolbarItem(placement: .primaryAction) {
-      addInfoBtn
+      additionalInfoBtn
     }
   }
 
@@ -84,15 +88,13 @@ extension GestureDetailContainer {
     .pickerStyle(.segmented)
   }
 
-  private var addInfoBtn: some View {
+  private var additionalInfoBtn: some View {
     Button {
-
+      showSheet = true
     } label: {
       Image(systemName: "questionmark.circle")
     }
-
   }
-
 }
 // MARK: 프리뷰
 struct GestureDetailContainer_Previews: PreviewProvider {

--- a/Gesture-Study/GestureStudy/View/GestureDetailContainer.swift
+++ b/Gesture-Study/GestureStudy/View/GestureDetailContainer.swift
@@ -1,0 +1,105 @@
+//
+//  GestureDetailContainer.swift
+//  GestureStudy
+//
+//  Created by JongHo Park on 2022/04/28.
+//
+
+import SwiftUI
+
+struct GestureDetailContainer<GestureDetail: GestureDetailProtocol>: View {
+  @State private var detailType: DetailType = .example
+  private let gestureDetail: GestureDetail
+
+  init(detail gestureDetail: GestureDetail) {
+    self.gestureDetail = gestureDetail
+    UISegmentedControl.appearance().selectedSegmentTintColor = UIColor(.brand)
+
+  }
+
+  var body: some View {
+    VStack(alignment: .leading) {
+      if case DetailType.example = detailType {
+        simpleDescription
+      }
+      content
+    }
+    .navigationTitle(gestureDetail.enNm)
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .background(Color.background.edgesIgnoringSafeArea(.all))
+    .toolbar(content: toolbar)
+  }
+
+  // MARK: - Gesture 의 간단한 설명 Text
+  private var simpleDescription: some View {
+    Text(gestureDetail.shortDescription)
+      .font(.body)
+      .foregroundColor(.subText)
+      .padding(.init(top: 14, leading: 16, bottom: 0, trailing: 16))
+  }
+
+  // MARK: - Content
+  @ViewBuilder
+  private var content: some View {
+    switch detailType {
+      case .example:
+        gestureDetail.exampleView
+      case .code:
+        Text(gestureDetail.swiftCode)
+    }
+  }
+}
+
+// MARK: - 설명 / 코드 enum
+extension GestureDetailContainer {
+
+  enum DetailType: String, CaseIterable {
+    case example = "설명"
+    case code = "코드"
+  }
+
+}
+
+// MARK: 툴바 모음
+extension GestureDetailContainer {
+  @ToolbarContentBuilder
+  func toolbar() -> some ToolbarContent {
+    ToolbarItem(placement: .principal) {
+      segmentedPicker
+    }
+    ToolbarItem(placement: .primaryAction) {
+      addInfoBtn
+    }
+  }
+
+  private var segmentedPicker: some View {
+    Picker("DetailType", selection: $detailType) {
+      ForEach(DetailType.allCases, id: \.self) {
+        Text($0.rawValue)
+          .padding()
+          .tag($0)
+          .tint(.brand)
+      }
+    }
+    .pickerStyle(.segmented)
+  }
+
+  private var addInfoBtn: some View {
+    Button {
+
+    } label: {
+      Image(systemName: "questionmark.circle")
+    }
+
+  }
+
+}
+// MARK: 프리뷰
+struct GestureDetailContainer_Previews: PreviewProvider {
+  static var previews: some View {
+    NavigationView {
+      GestureDetailContainer(detail: Tap())
+        .preferredColorScheme(.dark)
+    }
+  }
+}

--- a/Gesture-Study/GestureStudy/View/GestureDetailGridView.swift
+++ b/Gesture-Study/GestureStudy/View/GestureDetailGridView.swift
@@ -29,7 +29,10 @@ struct GestureDetailGridView: View {
   private var gridView: some View {
     LazyVGrid(columns: [GridItem(.flexible(), spacing: 0), GridItem(.flexible(), spacing: 0)], spacing: 14) {
       ForEach([Tap()]) { detail in
-        GestureDetailGridItem(gestureDetail: detail)
+        NavigationLink(destination: GestureDetailContainer(detail: detail)) {
+          GestureDetailGridItem(gestureDetail: detail)
+        }
+        .buttonStyle(.plain)
       }
     }
   }


### PR DESCRIPTION
## 개요
|![image](https://user-images.githubusercontent.com/57793298/165743665-e4dff7d1-ee01-4396-aa0a-b93c6444b575.png)|![image](https://user-images.githubusercontent.com/57793298/165743835-bff4ae37-a53e-4418-a912-1da5cafd2ce3.png)|

Gesture Detail 모델의 모든 정보를 보여줄 수 있는 위 이미지의 View 들을 구현

## 작업사항
- [Segmented Picker 구현](https://github.com/HoJongPARK/Gesture-Study/commit/12faa9709407e63e0e811e1b2c050cce18db7ea2#diff-540f560878c56a2c637e45e570fc02711f389fc964b0f546b48883d31a5d621aR75-R85)
- [Additional Info Btn 구현](https://github.com/HoJongPARK/Gesture-Study/commit/8e32310a5e90f6803e41b03c13aea425f09605d2#diff-540f560878c56a2c637e45e570fc02711f389fc964b0f546b48883d31a5d621aR91)
- [Example View Container 구현](https://github.com/HoJongPARK/Gesture-Study/commit/12faa9709407e63e0e811e1b2c050cce18db7ea2#diff-540f560878c56a2c637e45e570fc02711f389fc964b0f546b48883d31a5d621aR43-R50)
- [Bottom Sheet Container 구현](https://github.com/HoJongPARK/Gesture-Study/commit/8e32310a5e90f6803e41b03c13aea425f09605d2#diff-9a68792b0a6669eeb75c8ff9571a588ba61e2d7254ea1cdb4813334e73e47232R10-R66)

## 사용방법
- **Gesture Detail Container 에 GestureDetail 프로토콜을 구현하는 구현체를 넣으면 사용 가능**
